### PR TITLE
chore(github): agregar template de pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## 📋 Descripción
+<!-- Breve resumen de los cambios y el contexto del problema que resuelven -->
+
+## 🔗 Issue relacionado
+Closes #
+
+## 🧪 Tipo de cambio
+- [ ] ✨ Nueva funcionalidad
+- [ ] 🐛 Corrección de bug
+- [ ] ♻️ Refactor
+- [ ] 📝 Documentación
+- [ ] 🔧 Configuración / chore
+
+## 🖼️ Capturas de pantalla (si aplica)
+<!-- Añade imágenes o GIFs si hay cambios visuales -->
+
+## ✅ Checklist
+- [ ] El código sigue los estándares del proyecto
+- [ ] He añadido / actualizado los tests necesarios
+- [ ] He actualizado la documentación si aplica
+- [ ] He probado los cambios localmente
+- [ ] No hay conflictos con la rama base
+
+## 💬 Notas para el revisor
+<!-- Contexto adicional, decisiones de diseño, áreas que requieren atención especial -->


### PR DESCRIPTION
## 📋 Descripción
Se agrega el archivo `.github/PULL_REQUEST_TEMPLATE.md` para estandarizar la estructura de los Pull Requests en el repositorio. A partir de este merge, GitHub cargará automáticamente el template cada vez que se abra un nuevo PR.

## 🔗 Issue relacionado

## 🧪 Tipo de cambio
- [ ] ✨ Nueva funcionalidad
- [ ] 🐛 Corrección de bug
- [ ] ♻️ Refactor
- [x] 📝 Documentación
- [x] 🔧 Configuración / chore

## 🖼️ Capturas de pantalla (si aplica)
N/A

## ✅ Checklist
- [x] El código sigue los estándares del proyecto
- [x] He añadido / actualizado los tests necesarios
- [x] He actualizado la documentación si aplica
- [x] He probado los cambios localmente
- [x] No hay conflictos con la rama base

## 💬 Notas para el revisor
El template entra en efecto una vez mergeado a `main`. No requiere configuración adicional en GitHub.